### PR TITLE
Cluster installation inherit the xtrace setting from devstack plugin

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -130,7 +130,7 @@ function install_k8s_cloud_provider {
     $SYSTEMCTL stop $ETCD_SYSTEMD_SERVICE
 
     # local-up-cluster.sh compiles everything from source and starts the services.
-    sudo -E PATH=$PATH ./hack/local-up-cluster.sh
+    sudo -E PATH=$PATH SHELLOPTS=$SHELLOPTS ./hack/local-up-cluster.sh
 
     popd >/dev/null
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For now, the devstack installation will enable the xtrace when run the plugin script, it's helpful for checking the details of plugin installation with the logs. This PR make the k8s cluster installation script inherit the xtrace setting of the plugin.sh so that we can check the k8s cluster installation details in job logs.

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:

