### PR TITLE
Launch openstack-cloud-controller-manager after devstack installed

### DIFF
--- a/devstack/plugin.sh
+++ b/devstack/plugin.sh
@@ -120,6 +120,30 @@ function install_k8s_cloud_provider {
     export KUBE_ENABLE_CLUSTER_DNS=true
     export LOG_LEVEL=10
 
+    pushd ${BASE_DIR}
+    make build
+    popd
+
+    export EXTERNAL_CLOUD_PROVIDER_BINARY=${BASE_DIR}/openstack-cloud-controller-manager
+    export EXTERNAL_CLOUD_PROVIDER=true
+    export CLOUD_PROVIDER=openstack
+    export CLOUD_CONFIG=${CLOUD_CONFIG_FILE}
+
+    sudo pwd
+    if [[ ! -d "${CLOUD_CONFIG_DIR}" ]]; then
+        sudo mkdir -p ${CLOUD_CONFIG_DIR}
+    fi
+    sudo chown $STACK_USER /etc/kubernetes/
+    iniset ${CLOUD_CONFIG} Global region RegionOne
+    iniset ${CLOUD_CONFIG} Global username admin
+    iniset ${CLOUD_CONFIG} Global password secretadmin
+    iniset ${CLOUD_CONFIG} Global auth-url "http://localhost/identity"
+    iniset ${CLOUD_CONFIG} Global tenant-id $(openstack project show admin -f value -c id)
+    iniset ${CLOUD_CONFIG} Global domain-id default
+    iniset ${CLOUD_CONFIG} LoadBalancer subnet-id $(openstack subnet show lb-mgmt-subnet -f value -c id)
+    iniset ${CLOUD_CONFIG} LoadBalancer floating-network-id $(openstack network show public -f value -c id)
+    iniset ${CLOUD_CONFIG} BlockStorage bs-version v2
+
     # Listen on all interfaces
     export KUBELET_HOST="0.0.0.0"
 

--- a/devstack/settings
+++ b/devstack/settings
@@ -2,3 +2,5 @@
 
 enable_service k8s-cloud-provider
 enable_service kubernetes
+CLOUD_CONFIG_DIR=${CLOUD_CONFIG:-/etc/kubernetes}
+CLOUD_CONFIG_FILE=${CLOUD_CONFIG_DIR}/cloud-config


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This change config and allow the local-up-cluster.sh script launch the openstack-cloud-controller-manager process after devstack installation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #75 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
