### PR TITLE
Update the Cinder CSI driver to 0.2.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,15 @@
-hash: 20f016b53e26bafbb0a4246cc2ba25697144cf0ebcb8c90b7828191494d403ee
-updated: 2018-02-08T14:53:51.6031001-05:00
+hash: 7d2350d7cd7e585adeee2dd848621258f8cb861bf743f09d48409db296db3966
+updated: 2018-03-15T14:53:34.174086399+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
 - name: github.com/container-storage-interface/spec
-  version: 9e88e4bfabeca1b8e4810555815f112159292ada
+  version: 35d9f9d77954980e449e52c3f3e43c21bd8171f5
   subpackages:
   - lib/go/csi
+  - lib/go/csi/v0
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
@@ -40,7 +41,7 @@ imports:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
@@ -115,7 +116,7 @@ imports:
 - name: github.com/juju/ratelimit
   version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/kubernetes-csi/drivers
-  version: a862fcb47b62717ed139cfba3f03d298380f5135
+  version: 584f9dee7fb6b0bc0177863296db0443782376b7
   subpackages:
   - pkg/cinder
   - pkg/csi-common

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,10 @@
 package: git.openstack.org/openstack/openstack-cloud-controller-manager
 import:
 - package: github.com/container-storage-interface/spec
-  version: 9e88e4bfabeca1b8e4810555815f112159292ada
+  version: v0.2.0
   subpackages:
   - lib/go/csi
+  - lib/go/csi/v0
 - package: github.com/golang/glog
 - package: github.com/gophercloud/gophercloud
   version: e6eebf4bc729a74c834d96d950a804ab61015b0a

--- a/pkg/csi/cinder/controllerserver.go
+++ b/pkg/csi/cinder/controllerserver.go
@@ -17,9 +17,9 @@ limitations under the License.
 package cinder
 
 import (
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/golang/glog"
 	"git.openstack.org/openstack/openstack-cloud-controller-manager/pkg/csi/cinder/openstack"
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"github.com/golang/glog"
 	csicommon "github.com/kubernetes-csi/drivers/pkg/csi-common"
 	"github.com/pborman/uuid"
 	"golang.org/x/net/context"
@@ -68,7 +68,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	glog.V(4).Infof("Create volume %s in Availability Zone: %s", resID, resAvailability)
 
 	return &csi.CreateVolumeResponse{
-		VolumeInfo: &csi.VolumeInfo{
+		Volume: &csi.Volume{
 			Id: resID,
 			Attributes: map[string]string{
 				"availability": resAvailability,
@@ -137,7 +137,7 @@ func (cs *controllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	pvInfo["DevicePath"] = devicePath
 
 	return &csi.ControllerPublishVolumeResponse{
-		PublishVolumeInfo: pvInfo,
+		PublishInfo: pvInfo,
 	}, nil
 }
 

--- a/pkg/csi/cinder/controllerserver_test.go
+++ b/pkg/csi/cinder/controllerserver_test.go
@@ -19,7 +19,7 @@ package cinder
 import (
 	"testing"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"git.openstack.org/openstack/openstack-cloud-controller-manager/pkg/csi/cinder/openstack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -49,7 +49,6 @@ func TestCreateVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.CreateVolumeRequest{
-		Version:            &version,
 		Name:               fakeVolName,
 		VolumeCapabilities: nil,
 	}
@@ -61,11 +60,11 @@ func TestCreateVolume(t *testing.T) {
 	}
 
 	// Assert
-	assert.NotNil(actualRes.VolumeInfo)
+	assert.NotNil(actualRes.Volume)
 
-	assert.NotEqual(0, len(actualRes.VolumeInfo.Id), "Volume Id is nil")
+	assert.NotEqual(0, len(actualRes.Volume.Id), "Volume Id is nil")
 
-	assert.Equal(fakeAvailability, actualRes.VolumeInfo.Attributes["availability"])
+	assert.Equal(fakeAvailability, actualRes.Volume.Attributes["availability"])
 }
 
 // Test DeleteVolume
@@ -82,7 +81,6 @@ func TestDeleteVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.DeleteVolumeRequest{
-		Version:  &version,
 		VolumeId: fakeVolID,
 	}
 
@@ -117,7 +115,6 @@ func TestControllerPublishVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.ControllerPublishVolumeRequest{
-		Version:          &version,
 		VolumeId:         fakeVolID,
 		NodeId:           fakeNodeID,
 		VolumeCapability: nil,
@@ -126,7 +123,7 @@ func TestControllerPublishVolume(t *testing.T) {
 
 	// Expected Result
 	expectedRes := &csi.ControllerPublishVolumeResponse{
-		PublishVolumeInfo: map[string]string{
+		PublishInfo: map[string]string{
 			"DevicePath": fakeDevicePath,
 		},
 	}
@@ -157,7 +154,6 @@ func TestControllerUnpublishVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.ControllerUnpublishVolumeRequest{
-		Version:  &version,
 		VolumeId: fakeVolID,
 		NodeId:   fakeNodeID,
 	}

--- a/pkg/csi/cinder/driver.go
+++ b/pkg/csi/cinder/driver.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cinder
 
 import (
-	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"github.com/golang/glog"
 
 	"git.openstack.org/openstack/openstack-cloud-controller-manager/pkg/csi/cinder/openstack"
@@ -42,24 +42,18 @@ const (
 )
 
 var (
-	version = csi.Version{
-		Minor: 1,
-	}
+	version = "0.2.0"
 )
 
-func GetSupportedVersions() []*csi.Version {
-	return []*csi.Version{&version}
-}
-
 func NewDriver(nodeID, endpoint string, cloudconfig string) *driver {
-	glog.Infof("Driver: %v version: %v", driverName, csicommon.GetVersionString(&version))
+	glog.Infof("Driver: %v version: %v", driverName, version)
 
 	d := &driver{}
 
 	d.endpoint = endpoint
 	d.cloudconfig = cloudconfig
 
-	csiDriver := csicommon.NewCSIDriver(driverName, &version, GetSupportedVersions(), nodeID)
+	csiDriver := csicommon.NewCSIDriver(driverName, version, nodeID)
 	csiDriver.AddControllerServiceCapabilities(
 		[]csi.ControllerServiceCapability_RPC_Type{
 			csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,

--- a/pkg/csi/cinder/nodeserver.go
+++ b/pkg/csi/cinder/nodeserver.go
@@ -17,7 +17,7 @@ limitations under the License.
 package cinder
 
 import (
-	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -31,7 +31,7 @@ type nodeServer struct {
 	*csicommon.DefaultNodeServer
 }
 
-func (ns *nodeServer) GetNodeID(ctx context.Context, req *csi.GetNodeIDRequest) (*csi.GetNodeIDResponse, error) {
+func (ns *nodeServer) NodeGetId(ctx context.Context, req *csi.NodeGetIdRequest) (*csi.NodeGetIdResponse, error) {
 
 	// Get Mount Provider
 	m, err := mount.GetMountProvider()
@@ -47,20 +47,20 @@ func (ns *nodeServer) GetNodeID(ctx context.Context, req *csi.GetNodeIDRequest) 
 	}
 
 	if len(nodeID) > 0 {
-		return &csi.GetNodeIDResponse{
+		return &csi.NodeGetIdResponse{
 			NodeId: nodeID,
 		}, nil
 	}
 
 	// Using default function
-	return ns.DefaultNodeServer.GetNodeID(ctx, req)
+	return ns.DefaultNodeServer.NodeGetId(ctx, req)
 }
 
 func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 
 	targetPath := req.GetTargetPath()
 	fsType := req.GetVolumeCapability().GetMount().GetFsType()
-	devicePath := req.GetPublishVolumeInfo()["DevicePath"]
+	devicePath := req.GetPublishInfo()["DevicePath"]
 
 	// Get Mount Provider
 	m, err := mount.GetMountProvider()
@@ -129,4 +129,12 @@ func (ns *nodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 	}
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
+}
+
+func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+	return &csi.NodeUnstageVolumeResponse{}, nil
+}
+
+func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+	return &csi.NodeStageVolumeResponse{}, nil
 }

--- a/pkg/csi/cinder/nodeserver_test.go
+++ b/pkg/csi/cinder/nodeserver_test.go
@@ -19,7 +19,7 @@ package cinder
 import (
 	"testing"
 
-	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"git.openstack.org/openstack/openstack-cloud-controller-manager/pkg/csi/cinder/mount"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -35,8 +35,8 @@ func init() {
 	}
 }
 
-// Test GetNodeID
-func TestGetNodeID(t *testing.T) {
+// Test NodeGetId
+func TestNodeGetId(t *testing.T) {
 
 	// mock MountMock
 	mmock := new(mount.MountMock)
@@ -48,19 +48,17 @@ func TestGetNodeID(t *testing.T) {
 	assert := assert.New(t)
 
 	// Expected Result
-	expectedRes := &csi.GetNodeIDResponse{
+	expectedRes := &csi.NodeGetIdResponse{
 		NodeId: fakeNodeID,
 	}
 
 	// Fake request
-	fakeReq := &csi.GetNodeIDRequest{
-		Version: &version,
-	}
+	fakeReq := &csi.NodeGetIdRequest{}
 
-	// Invoke GetNodeID
-	actualRes, err := fakeNs.GetNodeID(fakeCtx, fakeReq)
+	// Invoke NodeGetId
+	actualRes, err := fakeNs.NodeGetId(fakeCtx, fakeReq)
 	if err != nil {
-		t.Errorf("failed to GetNodeID: %v", err)
+		t.Errorf("failed to NodeGetId: %v", err)
 	}
 
 	// Assert
@@ -88,12 +86,11 @@ func TestNodePublishVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.NodePublishVolumeRequest{
-		Version:           &version,
-		VolumeId:          fakeVolID,
-		PublishVolumeInfo: map[string]string{"DevicePath": fakeDevicePath},
-		TargetPath:        fakeTargetPath,
-		VolumeCapability:  nil,
-		Readonly:          false,
+		VolumeId:         fakeVolID,
+		PublishInfo:      map[string]string{"DevicePath": fakeDevicePath},
+		TargetPath:       fakeTargetPath,
+		VolumeCapability: nil,
+		Readonly:         false,
 	}
 
 	// Invoke NodePublishVolume
@@ -126,7 +123,6 @@ func TestNodeUnpublishVolume(t *testing.T) {
 
 	// Fake request
 	fakeReq := &csi.NodeUnpublishVolumeRequest{
-		Version:    &version,
 		VolumeId:   fakeVolID,
 		TargetPath: fakeTargetPath,
 	}


### PR DESCRIPTION
Following what has been done in this commit[0], I've copied over the
changes to update the Cinder CSI driver in this repo to the CSI version
0.2.0. I kept kubernetes 1.9.2 as our target version, instead of
updating it to 1.10 as it was done in the referenced commit.

[0] https://github.com/kubernetes-csi/drivers/commit/7a17c9a5f8cbfa307256b3dda3ccf43ec4fdf46b