### PR TITLE
Allow Keystone API version to be anything from v3 to v3.x

### DIFF
--- a/pkg/identity/keystone/keystone.go
+++ b/pkg/identity/keystone/keystone.go
@@ -44,7 +44,7 @@ func createIdentityV3Provider(options gophercloud.AuthOptions, transport http.Ro
 	}
 
 	versions := []*utils.Version{
-		{ID: "v3.0", Priority: 30, Suffix: "/v3/"},
+		{ID: "v3", Priority: 30, Suffix: "/v3/"},
 	}
 	chosen, _, err := utils.ChooseVersion(client, versions)
 	if err != nil {
@@ -52,7 +52,7 @@ func createIdentityV3Provider(options gophercloud.AuthOptions, transport http.Ro
 	}
 
 	switch chosen.ID {
-	case "v3.0":
+	case "v3":
 		return client, nil
 	default:
 		// The switch statement must be out of date from the versions list.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Now k8s-keystone-auth supports only one API version - 3.0,
which is outdated and not recommended for usage.
This patch allows to use the full range of the existing v3 API
versions.

**Which issue this PR fixes** 
fixes #88 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
